### PR TITLE
Update cross-compiler to Go 1.9

### DIFF
--- a/s390x-cross-compiler/Dockerfile
+++ b/s390x-cross-compiler/Dockerfile
@@ -7,7 +7,7 @@ FROM debian:stretch-slim
 LABEL maintainer="George Bolo <gbolo@linuxctl.com>"
 
 # ARGUMENTS
-ARG   go_version=1.7.6
+ARG   go_version=1.9
 
 # ENVIRONMENT VARIABLES
 ENV   GO_VERSION=${go_version} \


### PR DESCRIPTION
Fabric now requires Go 1.9